### PR TITLE
Fix classpath bug in ConsumeTasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
+++ b/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
@@ -33,7 +33,7 @@ object ConsumeTasty {
         import java.nio.file.Paths
         // We need the Scala library jar in the classpath, and for some reason getURLs doesn't include it.  We need to
         // get it by force.  We get the URL for a class we know is in the Scala library jar and strip off the trailing class.
-        val scalaLibPath = cl.getResoure("scala/math/BigInt$.class").toURI.toString.takeWhile(_!='!')
+        val scalaLibPath = cl.getResource("scala/math/BigInt$.class").toURI.toString.takeWhile(_!='!')
         val newClasspath = cl.getURLs.map(url => Paths.get(url.toURI).toString) :+ scalaLibPath
         newClasspath.mkString("", java.io.File.pathSeparator, if (classpath0 == "") "" else java.io.File.pathSeparator + classpath0)
       case _ => classpath0

--- a/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
+++ b/compiler/src/dotty/tools/dotc/consumetasty/ConsumeTasty.scala
@@ -31,7 +31,10 @@ object ConsumeTasty {
         // Loads the classes loaded by this class loader
         // When executing `run` or `test` in sbt the classpath is not in the property java.class.path
         import java.nio.file.Paths
-        val newClasspath = cl.getURLs.map(url => Paths.get(url.toURI).toString)
+        // We need the Scala library jar in the classpath, and for some reason getURLs doesn't include it.  We need to
+        // get it by force.  We get the URL for a class we know is in the Scala library jar and strip off the trailing class.
+        val scalaLibPath = cl.getResoure("scala/math/BigInt$.class").toURI.toString.takeWhile(_!='!')
+        val newClasspath = cl.getURLs.map(url => Paths.get(url.toURI).toString) :+ scalaLibPath
         newClasspath.mkString("", java.io.File.pathSeparator, if (classpath0 == "") "" else java.io.File.pathSeparator + classpath0)
       case _ => classpath0
     }


### PR DESCRIPTION
Whenever I tried to do Tasty inspection using this:
```scala
ConsumeTasty("",List(myclass), new Consumer) // note "" classpath
```
I would then see a nasty exception.  The expectation is that with "" as the classpath that ConsumeTasty would look wherever my project class/tasty files go.  Reading through the code I can see this is actually the intention, but with one problem.  I see a note in ConsumeTasty.scala (under compiler) that it says that the classpath isn't set properly when run from sbt, so there's an alternate way to compute the classpath. 

Unfortunately this alternate way (for me anyway) seemed to be missing a critical element: the path to the Scala library itself!  If I passed in the path to the Scala lib jar as my classpath string, it worked as intended.

This PR uses a way to get that library jar path, and now it works, specifically I can pass "" as the classpath to ConsumeTasty and it doesn't crash.

NOTE:  While this method of getting the Scala library jar path works, there may be a better way to get it.